### PR TITLE
core: output newline is always LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+test/**/data/* text eol=lf

--- a/src/Atlas.Provider.Core/Program.cs
+++ b/src/Atlas.Provider.Core/Program.cs
@@ -43,13 +43,14 @@ namespace Atlas.Provider.Core
           }
           var sql = executor.ScriptDbContext(name);
           Console.SetOut(originalOut);
+          Console.Out.NewLine = "\n";
           if (!string.IsNullOrEmpty(sql))
           {
             if (ctxInfo["ProviderName"]!.ToString()!.EndsWith("SqlServer"))
             {
               Console.WriteLine("-- atlas:delimiter GO");
             }
-            Console.WriteLine(sql);
+            Console.WriteLine(sql.Replace(Environment.NewLine, "\n"));
           }
         }
         return 0;

--- a/src/Atlas.Provider.Core/Program.cs
+++ b/src/Atlas.Provider.Core/Program.cs
@@ -45,7 +45,6 @@ namespace Atlas.Provider.Core
           Console.SetOut(originalOut);
           if (!string.IsNullOrEmpty(sql))
           {
-            Console.Out.NewLine = "\n";
             if (ctxInfo["ProviderName"]!.ToString()!.EndsWith("SqlServer"))
             {
               Console.WriteLine("-- atlas:delimiter GO");

--- a/src/Atlas.Provider.Core/Program.cs
+++ b/src/Atlas.Provider.Core/Program.cs
@@ -11,7 +11,7 @@ namespace Atlas.Provider.Core
       try
       {
         var options = new Options(args);
-        // prevent any output from being written to the console, including warn, info, error etc messages from EF Core
+        // prevent any output from being written to the stdout, including warn, info, error etc messages from EF Core
         var originalOut = Console.Out;
         Console.SetOut(Console.Error);
         using var executor = new EFDesign(
@@ -45,6 +45,7 @@ namespace Atlas.Provider.Core
           Console.SetOut(originalOut);
           if (!string.IsNullOrEmpty(sql))
           {
+            Console.Out.NewLine = "\n";
             if (ctxInfo["ProviderName"]!.ToString()!.EndsWith("SqlServer"))
             {
               Console.WriteLine("-- atlas:delimiter GO");

--- a/src/Atlas.Provider.Demo/Program.cs
+++ b/src/Atlas.Provider.Demo/Program.cs
@@ -42,7 +42,11 @@ namespace DemoNamespace
                     options.UseSqlite("Data Source=localdatabase.db;");
                     break;
                 case "mysql":
-                    options.UseMySql("Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;", ServerVersion.Create(8, 0, 0, ServerType.MySql));
+                    options.UseMySql(
+                        "Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;",
+                        ServerVersion.Create(8, 0, 0, ServerType.MySql),
+                        optionsBuilder => optionsBuilder.DisableLineBreakToCharSubstition()
+                        );
                     break;
                 case "mariadb":
                     options.UseMySql("Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;", ServerVersion.Create(8, 7, 0, ServerType.MariaDb));

--- a/src/Atlas.Provider.Demo/Program.cs
+++ b/src/Atlas.Provider.Demo/Program.cs
@@ -84,6 +84,7 @@ namespace DemoNamespace
         [Column(TypeName = "decimal(5, 2)")]
         public decimal Rating { get; set; }
         public string Title { get; set; } = string.Empty;
+        [Comment("Content contains new lines \\n\\r and \n for example")]
         public string Content { get; set; } = string.Empty;
         public string Author { get; set; } = string.Empty;
         public List<Post>? Posts { get; set; }

--- a/test/Atlas.Provider.Test/GenerateSchemaTest.cs
+++ b/test/Atlas.Provider.Test/GenerateSchemaTest.cs
@@ -29,7 +29,10 @@ public class GenerateSchemaTest
     string output = process.StandardOutput.ReadToEnd();
     string error = process.StandardError.ReadToEnd();
     process.WaitForExit();
-    Assert.Equal(FileReader.Read(expectedFile), output);
+    string expected = FileReader.Read(expectedFile);
+    // expectedFile is LF, defined in .gitattributes
+    // output is platform-specific, so normalize to LF
+    Assert.Equal(FileReader.Read(expectedFile), output.ReplaceLineEndings("\n"));
     Assert.Equal("", error);
   }
 }

--- a/test/Atlas.Provider.Test/GenerateSchemaTest.cs
+++ b/test/Atlas.Provider.Test/GenerateSchemaTest.cs
@@ -29,10 +29,7 @@ public class GenerateSchemaTest
     string output = process.StandardOutput.ReadToEnd();
     string error = process.StandardError.ReadToEnd();
     process.WaitForExit();
-    string expected = FileReader.Read(expectedFile);
-    // expectedFile is LF, defined in .gitattributes
-    // output is platform-specific, so normalize to LF
-    Assert.Equal(FileReader.Read(expectedFile), output.ReplaceLineEndings("\n"));
+    Assert.Equal(FileReader.Read(expectedFile), output);
     Assert.Equal("", error);
   }
 }

--- a/test/Atlas.Provider.Test/data/mysql_default
+++ b/test/Atlas.Provider.Test/data/mysql_default
@@ -6,7 +6,8 @@ CREATE TABLE `Blogs` (
     `Url` varchar(200) CHARACTER SET utf8mb4 NOT NULL,
     `Rating` decimal(5,2) NOT NULL,
     `Title` longtext CHARACTER SET utf8mb4 NOT NULL,
-    `Content` longtext CHARACTER SET utf8mb4 NOT NULL,
+    `Content` longtext CHARACTER SET utf8mb4 NOT NULL COMMENT 'Content contains new lines \\n\\r and 
+ for example',
     `Author` varchar(200) CHARACTER SET utf8mb4 NOT NULL DEFAULT 'Anonymous',
     CONSTRAINT `PK_Blogs` PRIMARY KEY (`BlogId`),
     CONSTRAINT `AK_Blogs_Url` UNIQUE (`Url`)

--- a/test/Atlas.Provider.Test/data/postgres_default
+++ b/test/Atlas.Provider.Test/data/postgres_default
@@ -8,6 +8,8 @@ CREATE TABLE "Blogs" (
     CONSTRAINT "PK_Blogs" PRIMARY KEY ("BlogId"),
     CONSTRAINT "AK_Blogs_Url" UNIQUE ("Url")
 );
+COMMENT ON COLUMN "Blogs"."Content" IS 'Content contains new lines \n\r and 
+ for example';
 
 
 CREATE TABLE "Post" (

--- a/test/Atlas.Provider.Test/data/sqlite_default
+++ b/test/Atlas.Provider.Test/data/sqlite_default
@@ -1,9 +1,16 @@
 CREATE TABLE "Blogs" (
     "BlogId" INTEGER NOT NULL CONSTRAINT "PK_Blogs" PRIMARY KEY AUTOINCREMENT,
+
     "Url" varchar(200) NOT NULL,
+
     "Rating" decimal(5, 2) NOT NULL,
+
     "Title" TEXT NOT NULL,
+
+    -- Content contains new lines \n\r and 
+    --  for example
     "Content" TEXT NOT NULL,
+
     "Author" TEXT NOT NULL DEFAULT 'Anonymous',
     CONSTRAINT "AK_Blogs_Url" UNIQUE ("Url")
 );

--- a/test/Atlas.Provider.Test/data/sqlserver_default
+++ b/test/Atlas.Provider.Test/data/sqlserver_default
@@ -9,6 +9,11 @@ CREATE TABLE [Blogs] (
     CONSTRAINT [PK_Blogs] PRIMARY KEY ([BlogId]),
     CONSTRAINT [AK_Blogs_Url] UNIQUE ([Url])
 );
+DECLARE @defaultSchema AS sysname;
+SET @defaultSchema = SCHEMA_NAME();
+DECLARE @description AS sql_variant;
+SET @description = CONCAT(N'Content contains new lines \n\r and ', NCHAR(10), N' for example');
+EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSchema, 'TABLE', N'Blogs', 'COLUMN', N'Content';
 GO
 
 


### PR DESCRIPTION
### Acceptance Criteria

1. **Enable Atlas to Generate Migrations on Both Windows and Unix-like Systems**
   To achieve this, SQL test files should use LF line endings. This will be enforced using a `.gitattributes` file.✅

2. **Run Unit Tests on Both Windows and Unix-like Systems**
    Force the EF Provider to always produce LF line endings ✅

### Conclusion

Using `.gitattributes` to enforce LF line endings and replacing line endings with LF ensures compatibility across Windows and Unix-like systems.

cc @giautm 