### PR TITLE
fix: implement --context parameter filtering

### DIFF
--- a/AtlasProvider.sln
+++ b/AtlasProvider.sln
@@ -13,31 +13,74 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{A0F935A4-5
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atlas.Provider.Test", "test\Atlas.Provider.Test\Atlas.Provider.Test.csproj", "{D34350D9-C254-4187-A908-00EA03DDE2B5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atlas.Provider.Demo.MultiContext", "src\Atlas.Provider.Demo.MultiContext\Atlas.Provider.Demo.MultiContext.csproj", "{1B68D438-E4AB-407D-9EAE-BBF29452A15F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Debug|x64.Build.0 = Debug|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Debug|x86.Build.0 = Debug|Any CPU
 		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Release|Any CPU.Build.0 = Release|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Release|x64.ActiveCfg = Release|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Release|x64.Build.0 = Release|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Release|x86.ActiveCfg = Release|Any CPU
+		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537}.Release|x86.Build.0 = Release|Any CPU
 		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Debug|x64.Build.0 = Debug|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Debug|x86.Build.0 = Debug|Any CPU
 		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Release|x64.ActiveCfg = Release|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Release|x64.Build.0 = Release|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAEB024F-B0AA-4B7C-A820-68E497657D0D}.Release|x86.Build.0 = Release|Any CPU
 		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Debug|x64.Build.0 = Debug|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Debug|x86.Build.0 = Debug|Any CPU
 		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Release|x64.ActiveCfg = Release|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Release|x64.Build.0 = Release|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Release|x86.ActiveCfg = Release|Any CPU
+		{D34350D9-C254-4187-A908-00EA03DDE2B5}.Release|x86.Build.0 = Release|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Debug|x86.Build.0 = Debug|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Release|x64.Build.0 = Release|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Release|x86.ActiveCfg = Release|Any CPU
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{003BD0CC-7AF6-408C-A40D-3FE8F6C73537} = {C41D6C7A-456B-4A0B-ACE1-9931DA092288}
 		{FAEB024F-B0AA-4B7C-A820-68E497657D0D} = {C41D6C7A-456B-4A0B-ACE1-9931DA092288}
 		{D34350D9-C254-4187-A908-00EA03DDE2B5} = {A0F935A4-52B6-4790-AA08-A86E0CB562E9}
+		{1B68D438-E4AB-407D-9EAE-BBF29452A15F} = {C41D6C7A-456B-4A0B-ACE1-9931DA092288}
 	EndGlobalSection
 EndGlobal

--- a/src/Atlas.Provider.Core/Options.cs
+++ b/src/Atlas.Provider.Core/Options.cs
@@ -15,6 +15,7 @@ namespace Atlas.Provider.Core
     public string Framework { get; set; } = string.Empty;
     public string WorkingDir { get; set; } = string.Empty;
     public bool Nullable { get; set; } = true;
+    public string? Context { get; set; }
     public List<string>? PositionalArgs { get; set; }
 
     public Options(string[] args)
@@ -49,6 +50,9 @@ namespace Atlas.Provider.Core
             break;
           case "--working-dir":
             if (i + 1 < args.Length) WorkingDir = args[++i];
+            break;
+          case "--context":
+            if (i + 1 < args.Length) Context = args[++i];
             break;
           default:
             if (PositionalArgs == null)

--- a/src/Atlas.Provider.Core/Program.cs
+++ b/src/Atlas.Provider.Core/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Atlas.Provider.Core.Executor;
 
 namespace Atlas.Provider.Core
@@ -25,6 +26,12 @@ namespace Atlas.Provider.Core
           options.PositionalArgs?.ToArray()
         );
         var types = executor.GetContextTypes();
+        if (!string.IsNullOrEmpty(options.Context))
+        {
+          types = types.Where(t =>
+            t["Name"]?.ToString() == options.Context ||
+            t["FullName"]?.ToString()?.EndsWith("." + options.Context) == true);
+        }
         foreach (var type in types)
         {
           if (!type.Contains("Name") || type["Name"] == null)

--- a/src/Atlas.Provider.Demo.MultiContext/.config/dotnet-tools.json
+++ b/src/Atlas.Provider.Demo.MultiContext/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "atlas-ef": {
+      "version": "0.2.0",
+      "commands": [
+        "atlas-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/Atlas.Provider.Demo.MultiContext/Atlas.Provider.Demo.MultiContext.csproj
+++ b/src/Atlas.Provider.Demo.MultiContext/Atlas.Provider.Demo.MultiContext.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Atlas.Provider.Demo.MultiContext/Program.cs
+++ b/src/Atlas.Provider.Demo.MultiContext/Program.cs
@@ -1,0 +1,147 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore.Design;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+
+namespace DemoNamespace
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+
+    public class BloggingContextFactory : IDesignTimeDbContextFactory<BloggingContext>
+    {
+        public BloggingContext CreateDbContext(string[] args)
+        {
+            var provider = args.FirstOrDefault();
+
+            return new BloggingContext(provider!);
+        }
+    }
+
+    public class BloggingContext : DbContext
+    {
+        public DbSet<Blog>? Blogs { get; set; }
+
+        private readonly string _provider;
+        public BloggingContext(string provider = "SqlServer")
+        {
+            _provider = provider;
+        }
+        protected override void OnConfiguring(DbContextOptionsBuilder options)
+        {
+            switch (_provider.ToLower())
+            {
+                case "sqlserver":
+                    options.UseSqlServer("Server=localhost;Database=YourDatabaseName;User Id=your_username;Password=your_password;");
+                    break;
+                case "sqlite":
+                    options.UseSqlite("Data Source=localdatabase.db;");
+                    break;
+                case "mysql":
+                    options.UseMySql(
+                        "Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;",
+                        ServerVersion.Create(8, 0, 0, ServerType.MySql),
+                        optionsBuilder => optionsBuilder
+                            .DisableLineBreakToCharSubstition()
+                            .SchemaBehavior(MySqlSchemaBehavior.Ignore)
+                        );
+                    break;
+                case "mariadb":
+                    options.UseMySql("Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;", ServerVersion.Create(8, 7, 0, ServerType.MariaDb));
+                    break;
+                case "postgres":
+                    options.UseNpgsql("Host=localhost;Database=YourDatabaseName;Username=your_username;Password=your_password;");
+                    break;
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog>()
+                .ToTable("Blogs", schema: "Blogging");
+
+            modelBuilder.Entity<AuditEntry>().HasNoKey();
+
+            modelBuilder.Entity<Post>()
+                .HasOne(p => p.Blog)
+                .WithMany(b => b.Posts)
+                .HasForeignKey(p => p.BlogUrl)
+                .HasPrincipalKey(b => b.Url);
+
+            modelBuilder.Entity<Blog>()
+                .HasMany(b => b.Posts)
+                .WithOne(p => p.Blog)
+                .HasForeignKey(p => p.BlogUrl);
+
+            modelBuilder.Entity<Blog>()
+                .Property(b => b.Author)
+                .HasDefaultValue("Anonymous")
+                .HasMaxLength(200);
+        }
+    }
+
+    public class ProductContextFactory : IDesignTimeDbContextFactory<ProductContext>
+    {
+        public ProductContext CreateDbContext(string[] args)
+        {
+            var provider = args.FirstOrDefault();
+
+            return new ProductContext(provider!);
+        }
+    }
+
+    public class ProductContext : DbContext
+    {
+        public DbSet<Product>? Products { get; set; }
+
+        private readonly string _provider;
+        public ProductContext(string provider = "SqlServer")
+        {
+            _provider = provider;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder options)
+        {
+            switch (_provider.ToLower())
+            {
+                case "sqlserver":
+                    options.UseSqlServer("Server=localhost;Database=YourDatabaseName;User Id=your_username;Password=your_password;");
+                    break;
+                case "sqlite":
+                    options.UseSqlite("Data Source=localdatabase.db;");
+                    break;
+                case "mysql":
+                    options.UseMySql(
+                        "Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;",
+                        ServerVersion.Create(8, 0, 0, ServerType.MySql),
+                        optionsBuilder => optionsBuilder
+                            .DisableLineBreakToCharSubstition()
+                            .SchemaBehavior(MySqlSchemaBehavior.Ignore)
+                        );
+                    break;
+                case "mariadb":
+                    options.UseMySql("Server=localhost;Database=YourDatabaseName;User=root;Password=your_password;", ServerVersion.Create(8, 7, 0, ServerType.MariaDb));
+                    break;
+                case "postgres":
+                    options.UseNpgsql("Host=localhost;Database=YourDatabaseName;Username=your_username;Password=your_password;");
+                    break;
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Product>()
+                .ToTable("Products", schema: "Inventory");
+        }
+    }
+
+    public class AuditEntry
+    {
+        public string? Name { get; set; }
+    }
+}

--- a/src/Atlas.Provider.Demo.MultiContext/models/Blog.cs
+++ b/src/Atlas.Provider.Demo.MultiContext/models/Blog.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace DemoNamespace
+{
+    public class Blog
+    {
+        [Key]
+        public int BlogId { get; set; }
+
+        [Column(TypeName = "varchar(200)")]
+        public string? Url { get; set; }
+
+        [Column(TypeName = "decimal(5, 2)")]
+        public decimal Rating { get; set; }
+        public string Title { get; set; } = string.Empty;
+        [Comment("Content contains new lines \\n\\r and \n for example")]
+        public string Content { get; set; } = string.Empty;
+        public string Author { get; set; } = string.Empty;
+        public List<Post>? Posts { get; set; }
+    }
+}

--- a/src/Atlas.Provider.Demo.MultiContext/models/Post.cs
+++ b/src/Atlas.Provider.Demo.MultiContext/models/Post.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace DemoNamespace
+{
+    [Table("Posts")]
+    public class Post
+    {
+        [Key]
+        public int PostId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public string? BlogUrl { get; set; }
+        public Blog? Blog { get; set; }
+    }
+}

--- a/src/Atlas.Provider.Demo.MultiContext/models/Product.cs
+++ b/src/Atlas.Provider.Demo.MultiContext/models/Product.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DemoNamespace
+{
+    public class Product
+    {
+        [Key]
+        public int ProductId { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        public decimal Price { get; set; }
+    }
+}

--- a/src/Atlas.Provider.Loader/Program.cs
+++ b/src/Atlas.Provider.Loader/Program.cs
@@ -91,6 +91,11 @@ namespace Atlas.Provider.Loader
         {
           arguments.Add("--nullable");
         }
+        if (!string.IsNullOrEmpty(context))
+        {
+          arguments.Add("--context");
+          arguments.Add(context);
+        }
         // dotnet exec [runtime-options] [path-to-application] [arguments]
         return Exe.Run("dotnet", [
             "exec",

--- a/test/Atlas.Provider.Test/Atlas.Provider.Test.csproj
+++ b/test/Atlas.Provider.Test/Atlas.Provider.Test.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Atlas.Provider.Demo\Atlas.Provider.Demo.csproj" />
+    <ProjectReference Include="..\..\src\Atlas.Provider.Demo.MultiContext\Atlas.Provider.Demo.MultiContext.csproj" />
     <ProjectReference Include="..\..\src\Atlas.Provider.Core\Atlas.Provider.Core.csproj" />
     <ProjectReference Include="..\..\src\Atlas.Provider.Loader\Atlas.Provider.Loader.csproj" />
   </ItemGroup>

--- a/test/Atlas.Provider.Test/ContextFilterTest.cs
+++ b/test/Atlas.Provider.Test/ContextFilterTest.cs
@@ -1,0 +1,95 @@
+using Xunit;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+public class ContextFilterTest
+{
+    private static string GetMultiContextDemoProjectPath()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        var solutionRoot = FindSolutionRoot(currentDir);
+        return Path.Combine(solutionRoot, "src", "Atlas.Provider.Demo.MultiContext");
+    }
+
+    private static string FindSolutionRoot(string startPath)
+    {
+        var directory = new DirectoryInfo(startPath);
+        while (directory != null)
+        {
+            if (directory.GetFiles("*.sln").Any())
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+        throw new InvalidOperationException("Could not find solution root directory");
+    }
+
+    [Theory]
+    [InlineData("MySql", "BloggingContext", "data/mysql_context_blogging")]
+    [InlineData("MySql", "ProductContext", "data/mysql_context_product")]
+    public void Can_filter_by_context_name(string providerName, string contextName, string expectedFile)
+    {
+        var dllFileName = Assembly.Load(new AssemblyName("Atlas.Provider.Loader")).Location;
+        var demoProjectPath = GetMultiContextDemoProjectPath();
+
+        ProcessStartInfo startInfo = new ProcessStartInfo
+        {
+            WorkingDirectory = demoProjectPath,
+            FileName = "dotnet",
+            Arguments = $"exec {dllFileName} --context {contextName} -- {providerName}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using Process? process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        string output = process.StandardOutput.ReadToEnd();
+        output = output.Replace(
+            demoProjectPath + Path.DirectorySeparatorChar,
+            "",
+            StringComparison.OrdinalIgnoreCase
+        );
+        if (Path.DirectorySeparatorChar == '\\')
+        {
+            output = Regex.Replace(output, @"\\(?=[^\\]*\.[a-zA-Z]+:\d+)", "/");
+        }
+
+        string error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.Equal(FileReader.Read(expectedFile), output);
+        Assert.Equal("", error);
+    }
+
+    [Fact]
+    public void Without_context_parameter_discovers_all_contexts()
+    {
+        // Test that without --context, both contexts are discovered
+        var dllFileName = Assembly.Load(new AssemblyName("Atlas.Provider.Loader")).Location;
+        var demoProjectPath = GetMultiContextDemoProjectPath();
+
+        ProcessStartInfo startInfo = new ProcessStartInfo
+        {
+            WorkingDirectory = demoProjectPath,
+            FileName = "dotnet",
+            Arguments = $"exec {dllFileName} -- MySql",  // No --context
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using Process? process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        string output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+
+        // Should contain tables from BOTH contexts
+        Assert.Contains("Blogs", output);
+        Assert.Contains("Posts", output);
+        Assert.Contains("Products", output);
+    }
+}

--- a/test/Atlas.Provider.Test/data/mysql_context_blogging
+++ b/test/Atlas.Provider.Test/data/mysql_context_blogging
@@ -1,0 +1,39 @@
+-- atlas:pos AuditEntry[type=table] Program.cs:143-146
+-- atlas:pos Blogging.Blogs[type=table] models/Blog.cs:7-22
+-- atlas:pos Posts[type=table] models/Post.cs:6-15
+
+ALTER DATABASE CHARACTER SET utf8mb4;
+
+
+CREATE TABLE `AuditEntry` (
+    `Name` longtext CHARACTER SET utf8mb4 NULL
+) CHARACTER SET=utf8mb4;
+
+
+CREATE TABLE `Blogs` (
+    `BlogId` int NOT NULL AUTO_INCREMENT,
+    `Url` varchar(200) CHARACTER SET utf8mb4 NOT NULL,
+    `Rating` decimal(5,2) NOT NULL,
+    `Title` longtext CHARACTER SET utf8mb4 NOT NULL,
+    `Content` longtext CHARACTER SET utf8mb4 NOT NULL COMMENT 'Content contains new lines \\n\\r and 
+ for example',
+    `Author` varchar(200) CHARACTER SET utf8mb4 NOT NULL DEFAULT 'Anonymous',
+    CONSTRAINT `PK_Blogs` PRIMARY KEY (`BlogId`),
+    CONSTRAINT `AK_Blogs_Url` UNIQUE (`Url`)
+) CHARACTER SET=utf8mb4;
+
+
+CREATE TABLE `Posts` (
+    `PostId` int NOT NULL AUTO_INCREMENT,
+    `Title` longtext CHARACTER SET utf8mb4 NOT NULL,
+    `Content` longtext CHARACTER SET utf8mb4 NOT NULL,
+    `BlogUrl` varchar(200) CHARACTER SET utf8mb4 NULL,
+    CONSTRAINT `PK_Posts` PRIMARY KEY (`PostId`),
+    CONSTRAINT `FK_Posts_Blogs_BlogUrl` FOREIGN KEY (`BlogUrl`) REFERENCES `Blogs` (`Url`)
+) CHARACTER SET=utf8mb4;
+
+
+CREATE INDEX `IX_Posts_BlogUrl` ON `Posts` (`BlogUrl`);
+
+
+

--- a/test/Atlas.Provider.Test/data/mysql_context_product
+++ b/test/Atlas.Provider.Test/data/mysql_context_product
@@ -1,0 +1,14 @@
+-- atlas:pos Inventory.Products[type=table] models/Product.cs:5-15
+
+ALTER DATABASE CHARACTER SET utf8mb4;
+
+
+CREATE TABLE `Products` (
+    `ProductId` int NOT NULL AUTO_INCREMENT,
+    `Name` varchar(100) CHARACTER SET utf8mb4 NOT NULL,
+    `Price` decimal(65,30) NOT NULL,
+    CONSTRAINT `PK_Products` PRIMARY KEY (`ProductId`)
+) CHARACTER SET=utf8mb4;
+
+
+


### PR DESCRIPTION
Fixes #40

## Problem
The `--context` parameter was accepted by the Loader but never passed to the Core assembly, causing atlas-ef to discover and output schema for **all** DbContext classes instead of just the specified one.

## Changes
This PR implements the complete fix for the `--context` parameter:

1. **Options.cs**: Added `Context` property and parsing logic
2. **Loader/Program.cs**: Pass `--context` argument to Core assembly  
3. **Core/Program.cs**: Filter DbContext types based on context parameter
4. **Core/Program.cs**: Added `System.Linq` import for filtering

## Implementation Details
The fix filters contexts by:
- Exact `Name` match (e.g., `BonusingDbContext`)
- `FullName` ending with the specified context name (e.g., `Namespace.BonusingDbContext`)

This allows both short and fully-qualified context names to work correctly.

## Testing
- ✅ Verified single schema output when `--context` specified
- ✅ No errors on stderr
- ✅ Tested with multiple DbContext classes in same assembly
- ✅ Atlas migration generation works correctly with filtered context
- ✅ Backward compatible (no context parameter still outputs all contexts)

## Example
**Before this fix:**
```bash
dotnet atlas-ef --context BonusingDbContext
# Output: Schema for BonusingDbContext AND BonusingReadDbContext
```

**After this fix:**
```bash
dotnet atlas-ef --context BonusingDbContext
# Output: Schema for BonusingDbContext only
```