### PR TITLE
loader: fix .NET10 probing with local packaged deps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,8 +97,24 @@ jobs:
         shell: pwsh
         working-directory: ./src/Atlas.Provider.Demo
         run: |
-          (Get-Content Atlas.Provider.Demo.csproj) -replace '<TargetFramework>net6.0</TargetFramework>', '<TargetFramework>net${{ matrix.dotnet }}</TargetFramework>' | Set-Content Atlas.Provider.Demo.csproj
-          Get-Content Atlas.Provider.Demo.csproj
+          $csprojPath = "Atlas.Provider.Demo.csproj"
+          [xml]$xml = Get-Content $csprojPath
+          $updated = $false
+          foreach ($pg in $xml.Project.PropertyGroup) {
+            if ($pg.TargetFramework) {
+              $pg.TargetFramework = "net${{ matrix.dotnet }}"
+              $updated = $true
+            }
+            if ($pg.TargetFrameworks) {
+              $pg.TargetFrameworks = "net${{ matrix.dotnet }}"
+              $updated = $true
+            }
+          }
+          if (-not $updated) {
+            throw "No <TargetFramework> or <TargetFrameworks> element found in $csprojPath"
+          }
+          $xml.Save((Resolve-Path $csprojPath))
+          Get-Content $csprojPath
 
       - name: Test tool without context flag (all contexts)
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,9 +70,10 @@ jobs:
       - name: Install .NET Core SDK
         uses: actions/setup-dotnet@v3.2.0
         with:
+          # Need net6.0 for the tool and matrix SDK for the demo app target.
           dotnet-version: |
-            6.0.x # needed to build the tool (net6.0)
-            ${{ matrix.dotnet }}.x # matrix SDK for demo app target
+            6.0.x
+            ${{ matrix.dotnet }}.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Verify migrations generated
         shell: bash
         run: |
-          if git status --porcelain | grep -vq 'dotnet-tools.json' ; then
+          if git status --porcelain | grep -v 'dotnet-tools.json' | grep -vq 'Atlas.Provider.Demo.csproj' ; then
             echo "You need to run 'atlas migrate diff --env ef' and commit the changes"
             echo ""
             git status --porcelain

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,11 +53,13 @@ jobs:
           path: "./artifacts"
 
   test-tool:
-    name: Test tool on ${{ matrix.os }}
+    name: Test tool on ${{ matrix.os }} with .NET ${{ matrix.dotnet }}
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        dotnet: ['8.0', '9.0', '10.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -70,7 +72,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            8.0.x
+            ${{ matrix.dotnet }}.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -91,6 +93,13 @@ jobs:
           dotnet tool install --add-source ./nupkg --version "$version" -g atlas-ef
           echo "Installed atlas-ef version: $version"
           
+      - name: Update Demo Project TargetFramework
+        shell: pwsh
+        working-directory: ./src/Atlas.Provider.Demo
+        run: |
+          (Get-Content Atlas.Provider.Demo.csproj) -replace '<TargetFramework>net6.0</TargetFramework>', '<TargetFramework>net${{ matrix.dotnet }}</TargetFramework>' | Set-Content Atlas.Provider.Demo.csproj
+          Get-Content Atlas.Provider.Demo.csproj
+
       - name: Test tool without context flag (all contexts)
         shell: bash
         working-directory: ./src/Atlas.Provider.Demo

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,8 +71,8 @@ jobs:
         uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: |
-            6.0.x
-            ${{ matrix.dotnet }}.x
+            6.0.x # needed to build the tool (net6.0)
+            ${{ matrix.dotnet }}.x # matrix SDK for demo app target
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/src/Atlas.Provider.Loader/Program.cs
+++ b/src/Atlas.Provider.Loader/Program.cs
@@ -42,6 +42,20 @@ namespace Atlas.Provider.Loader
                 // Load the deps for the atlas provider core
                 "--additional-deps", Path.Combine(loaderDirPath!, AssemblyName + ".deps.json"),
             };
+        runtimeOpts.Add("--additionalprobingpath");
+        runtimeOpts.Add(loaderDirPath!);
+        var corePackagePath = Path.Combine(loaderDirPath!, AssemblyName);
+        if (Directory.Exists(corePackagePath))
+        {
+          runtimeOpts.Add("--additionalprobingpath");
+          runtimeOpts.Add(corePackagePath);
+        }
+        var localStore = EnsureLocalPackageStore(loaderDirPath!);
+        if (Directory.Exists(localStore))
+        {
+          runtimeOpts.Add("--additionalprobingpath");
+          runtimeOpts.Add(localStore);
+        }
         var projectAssetsFile = _startupProject.ProjectAssetsFile;
         if (!string.IsNullOrEmpty(projectAssetsFile))
         {
@@ -109,6 +123,78 @@ namespace Atlas.Provider.Loader
         Console.Error.WriteLine(ex.Message);
         return 1;
       }
+    }
+
+    private static string EnsureLocalPackageStore(string loaderDirPath)
+    {
+      var storeRoot = Path.Combine(loaderDirPath, ".packages");
+      try
+      {
+        var depsPath = Path.Combine(loaderDirPath, AssemblyName + ".deps.json");
+        if (!File.Exists(depsPath))
+        {
+          return storeRoot;
+        }
+        using var depsDoc = JsonDocument.Parse(File.ReadAllBytes(depsPath));
+        var runtimeTargetName = depsDoc.RootElement.GetProperty("runtimeTarget").GetProperty("name").GetString();
+        if (string.IsNullOrEmpty(runtimeTargetName))
+        {
+          return storeRoot;
+        }
+        var targets = depsDoc.RootElement.GetProperty("targets").GetProperty(runtimeTargetName);
+        var libraries = depsDoc.RootElement.GetProperty("libraries");
+        var filesByName = Directory.EnumerateFiles(loaderDirPath, "*", SearchOption.AllDirectories)
+          .ToLookup(Path.GetFileName, StringComparer.OrdinalIgnoreCase);
+        foreach (var lib in targets.EnumerateObject())
+        {
+          if (!libraries.TryGetProperty(lib.Name, out var libEntry))
+          {
+            continue;
+          }
+          var libPath = libEntry.TryGetProperty("path", out var pathProp) ? pathProp.GetString() : null;
+          var libType = libEntry.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
+          // For project refs (like Atlas.Provider.Core in our tool) there is no package path; use the library name.
+          if (string.IsNullOrEmpty(libPath))
+          {
+            libPath = lib.Name;
+          }
+          if (string.IsNullOrEmpty(libType))
+          {
+            libType = "project";
+          }
+          if (!lib.Value.TryGetProperty("runtime", out var runtimeAssets))
+          {
+            continue;
+          }
+          foreach (var asset in runtimeAssets.EnumerateObject())
+          {
+            var relAssetPath = asset.Name.Replace('/', Path.DirectorySeparatorChar);
+            var destPath = Path.Combine(storeRoot, libPath, relAssetPath);
+            var destDir = Path.GetDirectoryName(destPath);
+            if (destDir == null)
+            {
+              continue;
+            }
+            Directory.CreateDirectory(destDir);
+            if (File.Exists(destPath))
+            {
+              continue;
+            }
+            var fileName = Path.GetFileName(relAssetPath);
+            var source = filesByName[fileName].FirstOrDefault();
+            if (source == null)
+            {
+              continue;
+            }
+            File.Copy(source, destPath, true);
+          }
+        }
+      }
+      catch
+      {
+        // Best-effort; fall back to other probing paths if this fails.
+      }
+      return storeRoot;
     }
   }
 }

--- a/src/Atlas.Provider.Loader/Program.cs
+++ b/src/Atlas.Provider.Loader/Program.cs
@@ -128,6 +128,10 @@ namespace Atlas.Provider.Loader
     private static string EnsureLocalPackageStore(string loaderDirPath)
     {
       var storeRoot = Path.Combine(loaderDirPath, ".packages");
+      var storeRootFull = Path.GetFullPath(storeRoot);
+      var storeRootPrefix = storeRootFull.EndsWith(Path.DirectorySeparatorChar)
+        ? storeRootFull
+        : storeRootFull + Path.DirectorySeparatorChar;
       try
       {
         var depsPath = Path.Combine(loaderDirPath, AssemblyName + ".deps.json");
@@ -136,40 +140,67 @@ namespace Atlas.Provider.Loader
           return storeRoot;
         }
         using var depsDoc = JsonDocument.Parse(File.ReadAllBytes(depsPath));
-        var runtimeTargetName = depsDoc.RootElement.GetProperty("runtimeTarget").GetProperty("name").GetString();
+        var root = depsDoc.RootElement;
+        if (!root.TryGetProperty("runtimeTarget", out var runtimeTargetProp)
+            || !runtimeTargetProp.TryGetProperty("name", out var runtimeTargetNameProp))
+        {
+          return storeRoot;
+        }
+        var runtimeTargetName = runtimeTargetNameProp.GetString();
         if (string.IsNullOrEmpty(runtimeTargetName))
         {
           return storeRoot;
         }
-        var targets = depsDoc.RootElement.GetProperty("targets").GetProperty(runtimeTargetName);
-        var libraries = depsDoc.RootElement.GetProperty("libraries");
+        if (!root.TryGetProperty("targets", out var targetsProp)
+            || !targetsProp.TryGetProperty(runtimeTargetName, out var targets))
+        {
+          return storeRoot;
+        }
+        if (!root.TryGetProperty("libraries", out var libraries))
+        {
+          return storeRoot;
+        }
+
+        var runtimeLibs = new List<(string Name, JsonElement RuntimeAssets)>();
+        foreach (var lib in targets.EnumerateObject())
+        {
+          if (!lib.Value.TryGetProperty("runtime", out var runtimeAssets))
+          {
+            continue;
+          }
+          if (!runtimeAssets.EnumerateObject().Any())
+          {
+            continue;
+          }
+          runtimeLibs.Add((lib.Name, runtimeAssets));
+        }
+        if (runtimeLibs.Count == 0)
+        {
+          return storeRoot;
+        }
+
         var filesByName = Directory.EnumerateFiles(loaderDirPath, "*", SearchOption.AllDirectories)
           .ToLookup(Path.GetFileName, StringComparer.OrdinalIgnoreCase);
-        foreach (var lib in targets.EnumerateObject())
+        foreach (var lib in runtimeLibs)
         {
           if (!libraries.TryGetProperty(lib.Name, out var libEntry))
           {
             continue;
           }
           var libPath = libEntry.TryGetProperty("path", out var pathProp) ? pathProp.GetString() : null;
-          var libType = libEntry.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
           // For project refs (like Atlas.Provider.Core in our tool) there is no package path; use the library name.
           if (string.IsNullOrEmpty(libPath))
           {
             libPath = lib.Name;
           }
-          if (string.IsNullOrEmpty(libType))
-          {
-            libType = "project";
-          }
-          if (!lib.Value.TryGetProperty("runtime", out var runtimeAssets))
-          {
-            continue;
-          }
-          foreach (var asset in runtimeAssets.EnumerateObject())
+          foreach (var asset in lib.RuntimeAssets.EnumerateObject())
           {
             var relAssetPath = asset.Name.Replace('/', Path.DirectorySeparatorChar);
-            var destPath = Path.Combine(storeRoot, libPath, relAssetPath);
+            var destPath = Path.GetFullPath(Path.Combine(storeRootPrefix, libPath, relAssetPath));
+            if (!destPath.StartsWith(storeRootPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+              continue;
+            }
             var destDir = Path.GetDirectoryName(destPath);
             if (destDir == null)
             {

--- a/src/Atlas.Provider.Loader/Program.cs
+++ b/src/Atlas.Provider.Loader/Program.cs
@@ -161,18 +161,19 @@ namespace Atlas.Provider.Loader
           return storeRoot;
         }
 
-        var runtimeLibs = new List<(string Name, JsonElement RuntimeAssets)>();
+        var runtimeLibs = new List<(string Name, JsonProperty[] RuntimeAssets)>();
         foreach (var lib in targets.EnumerateObject())
         {
           if (!lib.Value.TryGetProperty("runtime", out var runtimeAssets))
           {
             continue;
           }
-          if (!runtimeAssets.EnumerateObject().Any())
+          var runtimeAssetProps = runtimeAssets.EnumerateObject().ToArray();
+          if (runtimeAssetProps.Length == 0)
           {
             continue;
           }
-          runtimeLibs.Add((lib.Name, runtimeAssets));
+          runtimeLibs.Add((lib.Name, runtimeAssetProps));
         }
         if (runtimeLibs.Count == 0)
         {
@@ -180,7 +181,9 @@ namespace Atlas.Provider.Loader
         }
 
         var filesByName = Directory.EnumerateFiles(loaderDirPath, "*", SearchOption.AllDirectories)
-          .ToLookup(Path.GetFileName, StringComparer.OrdinalIgnoreCase);
+          .Select(path => (Path: path, FileName: Path.GetFileName(path)))
+          .Where(t => !string.IsNullOrEmpty(t.FileName))
+          .ToLookup(t => t.FileName!, t => t.Path, StringComparer.OrdinalIgnoreCase);
         foreach (var lib in runtimeLibs)
         {
           if (!libraries.TryGetProperty(lib.Name, out var libEntry))
@@ -193,7 +196,7 @@ namespace Atlas.Provider.Loader
           {
             libPath = lib.Name;
           }
-          foreach (var asset in lib.RuntimeAssets.EnumerateObject())
+          foreach (var asset in lib.RuntimeAssets)
           {
             var relAssetPath = asset.Name.Replace('/', Path.DirectorySeparatorChar);
             var destPath = Path.GetFullPath(Path.Combine(storeRootPrefix, libPath, relAssetPath));
@@ -207,17 +210,13 @@ namespace Atlas.Provider.Loader
               continue;
             }
             Directory.CreateDirectory(destDir);
-            if (File.Exists(destPath))
-            {
-              continue;
-            }
             var fileName = Path.GetFileName(relAssetPath);
             var source = filesByName[fileName].FirstOrDefault();
             if (source == null)
             {
               continue;
             }
-            File.Copy(source, destPath, true);
+            File.Copy(source, destPath, false);
           }
         }
       }

--- a/src/Atlas.Provider.Loader/Program.cs
+++ b/src/Atlas.Provider.Loader/Program.cs
@@ -125,98 +125,87 @@ namespace Atlas.Provider.Loader
       }
     }
 
+    /// <summary>
+    /// Ensures a local package store exists by copying runtime assets from the loader directory.
+    /// This enables the .NET runtime to resolve dependencies when running Atlas.Provider.Core.
+    /// </summary>
+    /// <param name="loaderDirPath">The directory containing the loader assembly.</param>
+    /// <returns>The path to the local package store directory.</returns>
     private static string EnsureLocalPackageStore(string loaderDirPath)
     {
       var storeRoot = Path.Combine(loaderDirPath, ".packages");
-      var storeRootFull = Path.GetFullPath(storeRoot);
-      var storeRootPrefix = storeRootFull.EndsWith(Path.DirectorySeparatorChar)
-        ? storeRootFull
-        : storeRootFull + Path.DirectorySeparatorChar;
+      var depsPath = Path.Combine(loaderDirPath, AssemblyName + ".deps.json");
+
+      if (!File.Exists(depsPath))
+      {
+        return storeRoot;
+      }
+
       try
       {
-        var depsPath = Path.Combine(loaderDirPath, AssemblyName + ".deps.json");
-        if (!File.Exists(depsPath))
-        {
-          return storeRoot;
-        }
-        using var depsDoc = JsonDocument.Parse(File.ReadAllBytes(depsPath));
+        using var stream = File.OpenRead(depsPath);
+        using var depsDoc = JsonDocument.Parse(stream);
         var root = depsDoc.RootElement;
-        if (!root.TryGetProperty("runtimeTarget", out var runtimeTargetProp)
-            || !runtimeTargetProp.TryGetProperty("name", out var runtimeTargetNameProp))
-        {
-          return storeRoot;
-        }
-        var runtimeTargetName = runtimeTargetNameProp.GetString();
-        if (string.IsNullOrEmpty(runtimeTargetName))
-        {
-          return storeRoot;
-        }
-        if (!root.TryGetProperty("targets", out var targetsProp)
-            || !targetsProp.TryGetProperty(runtimeTargetName, out var targets))
-        {
-          return storeRoot;
-        }
-        if (!root.TryGetProperty("libraries", out var libraries))
+
+        if (!root.TryGetProperty("runtimeTarget", out var runtimeTargetProp) ||
+            !runtimeTargetProp.TryGetProperty("name", out var runtimeTargetNameProp) ||
+            runtimeTargetNameProp.GetString() is not { Length: > 0 } runtimeTargetName)
         {
           return storeRoot;
         }
 
-        var runtimeLibs = new List<(string Name, JsonProperty[] RuntimeAssets)>();
+        if (!root.TryGetProperty("targets", out var targetsProp) ||
+            !targetsProp.TryGetProperty(runtimeTargetName, out var targets) ||
+            !root.TryGetProperty("libraries", out var libraries))
+        {
+          return storeRoot;
+        }
+
+        Dictionary<string, string>? filesByName = null;
+
         foreach (var lib in targets.EnumerateObject())
         {
           if (!lib.Value.TryGetProperty("runtime", out var runtimeAssets))
           {
             continue;
           }
-          var runtimeAssetProps = runtimeAssets.EnumerateObject().ToArray();
-          if (runtimeAssetProps.Length == 0)
-          {
-            continue;
-          }
-          runtimeLibs.Add((lib.Name, runtimeAssetProps));
-        }
-        if (runtimeLibs.Count == 0)
-        {
-          return storeRoot;
-        }
 
-        var filesByName = Directory.EnumerateFiles(loaderDirPath, "*", SearchOption.AllDirectories)
-          .Select(path => (Path: path, FileName: Path.GetFileName(path)))
-          .Where(t => !string.IsNullOrEmpty(t.FileName))
-          .ToLookup(t => t.FileName!, t => t.Path, StringComparer.OrdinalIgnoreCase);
-        foreach (var lib in runtimeLibs)
-        {
           if (!libraries.TryGetProperty(lib.Name, out var libEntry))
           {
             continue;
           }
+
           var libPath = libEntry.TryGetProperty("path", out var pathProp) ? pathProp.GetString() : null;
-          // For project refs (like Atlas.Provider.Core in our tool) there is no package path; use the library name.
+          // For project refs (like Atlas.Provider.Core) there is no package path; use the library name.
           if (string.IsNullOrEmpty(libPath))
           {
             libPath = lib.Name;
           }
-          foreach (var asset in lib.RuntimeAssets)
+
+          foreach (var asset in runtimeAssets.EnumerateObject())
           {
             var relAssetPath = asset.Name.Replace('/', Path.DirectorySeparatorChar);
-            var destPath = Path.GetFullPath(Path.Combine(storeRootPrefix, libPath, relAssetPath));
-            if (!destPath.StartsWith(storeRootPrefix, StringComparison.OrdinalIgnoreCase))
+            var destPath = Path.Combine(storeRoot, libPath, relAssetPath);
+
+            // Skip if destination already exists
+            if (File.Exists(destPath))
             {
               continue;
             }
-            var destDir = Path.GetDirectoryName(destPath);
-            if (destDir == null)
-            {
-              continue;
-            }
-            Directory.CreateDirectory(destDir);
+
+            filesByName ??= BuildFileIndex(loaderDirPath);
             var fileName = Path.GetFileName(relAssetPath);
-            var source = filesByName[fileName].FirstOrDefault();
-            if (source == null)
+            if (!filesByName.TryGetValue(fileName, out var source))
             {
               continue;
             }
-            File.Copy(source, destPath, false);
+
+            var destDir = Path.GetDirectoryName(destPath);
+            if (!string.IsNullOrEmpty(destDir))
+            {
+              Directory.CreateDirectory(destDir);
+              File.Copy(source, destPath, overwrite: false);
+            }
           }
         }
       }
@@ -224,7 +213,22 @@ namespace Atlas.Provider.Loader
       {
         // Best-effort; fall back to other probing paths if this fails.
       }
+
       return storeRoot;
+    }
+
+    /// <summary>
+    /// Builds a case-insensitive index of file names to their full paths.
+    /// </summary>
+    private static Dictionary<string, string> BuildFileIndex(string directory)
+    {
+      var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+      foreach (var path in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+      {
+        var fileName = Path.GetFileName(path);
+        result.TryAdd(fileName, path);
+      }
+      return result;
     }
   }
 }


### PR DESCRIPTION
.NET 8/9 are able to find the tool-bundled assemblies without an explicit probing path, but for .NET 10, we have to explicitly set that.